### PR TITLE
fix(ci): lock upload artifact action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3
         with:
           name: bottles
           path: '*.bottle.*'


### PR DESCRIPTION
## Description

Lock `upload-artifact` action version to `v3`.

Ref:
- Corresponding commit in action generation https://github.com/Homebrew/brew/commit/29cf01d4422a49a69e5af0cfb169d939e9f4f5b0
- Issue https://github.com/actions/upload-artifact/issues/478