### PR TITLE
chore: remove libunwind dep

### DIFF
--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -17,7 +17,6 @@ class Reth < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "56c9cca150ef382a7a6cc705019e12703482d438830457f5f109feb106251357"
   end
 
-  depends_on "libunwind" => :build
   depends_on "llvm" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
`libunwind` is only available on Linux. I added it because of build issues and it resolved it without checking if it was available on macOS or not.

Seems to have been a temporary fluke or something? `libunwind` is not required anymore