### PR TITLE
ci: build for macos arm

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -17,12 +17,8 @@ class Reth < Formula
 
   def install
     features = []
-    if Hardware::CPU.intel? || OS.mac?
-      features.push("jemalloc")
-    end
-    unless Hardware::CPU.arm? && OS.linux?
-      features.push("asm-keccak")
-    end
+    features.push("jemalloc") if Hardware::CPU.intel? || OS.mac?
+    features.push("asm-keccak") if !(Hardware::CPU.arm? && OS.linux?)
 
     cd "bin/reth" do
       if features.any?

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -12,11 +12,6 @@ class Reth < Formula
     strategy :github_latest
   end
 
-  bottle do
-    root_url "https://github.com/paradigmxyz/homebrew-brew/releases/download/reth-0.2.0-beta.6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7b9c2d91b6ae69b5deace9d2678cec9e843bac772080bdc8191b9a49919d1111"
-  end
-
   depends_on "llvm" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -18,7 +18,9 @@ class Reth < Formula
   def install
     features = []
     features.push("jemalloc") if Hardware::CPU.intel? || OS.mac?
-    features.push("asm-keccak") if !(Hardware::CPU.arm? && OS.linux?)
+
+    is_arm_linux = Hardware::CPU.arm? && OS.linux?
+    features.push("asm-keccak") unless is_arm_linux
 
     cd "bin/reth" do
       if features.any?

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -16,9 +16,17 @@ class Reth < Formula
   depends_on "rust" => :build
 
   def install
+    features = []
+    if Hardware::CPU.intel? || OS.mac?
+      features.push("jemalloc")
+    end
+    unless Hardware::CPU.arm? && OS.linux?
+      features.push("asm-keccak")
+    end
+
     cd "bin/reth" do
-      if Hardware::CPU.intel? || OS.mac?
-        system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", "jemalloc", *std_cargo_args
+      if features.any?
+        system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", *features, *std_cargo_args
       else
         system "cargo", "install", "--bin", "reth", "--profile", "maxperf", *std_cargo_args
       end

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -24,7 +24,8 @@ class Reth < Formula
 
     cd "bin/reth" do
       if features.any?
-        system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", *features, *std_cargo_args
+        system "cargo", "install", "--bin", "reth", "--profile", "maxperf",
+          "--features", features.join(" "), *std_cargo_args
       else
         system "cargo", "install", "--bin", "reth", "--profile", "maxperf", *std_cargo_args
       end

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -18,13 +18,13 @@ class Reth < Formula
 
   def install
     if Hardware::CPU.intel?
-        cd "bin/reth" do
-            system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", "jemalloc", *std_cargo_args
-        end
+      cd "bin/reth" do
+        system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", "jemalloc", *std_cargo_args
+      end
     else
-        cd "bin/reth" do
-            system "cargo", "install", "--bin", "reth", "--profile", "maxperf", *std_cargo_args
-        end
+      cd "bin/reth" do
+        system "cargo", "install", "--bin", "reth", "--profile", "maxperf", *std_cargo_args
+      end
     end
   end
 

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -17,7 +17,7 @@ class Reth < Formula
 
   def install
     cd "bin/reth" do
-      if Hardware::CPU.intel? or OS.mac?
+      if Hardware::CPU.intel? || OS.mac?
         system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", "jemalloc", *std_cargo_args
       else
         system "cargo", "install", "--bin", "reth", "--profile", "maxperf", *std_cargo_args

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -16,12 +16,10 @@ class Reth < Formula
   depends_on "rust" => :build
 
   def install
-    if Hardware::CPU.intel?
-      cd "bin/reth" do
+    cd "bin/reth" do
+      if Hardware::CPU.intel? or OS.mac?
         system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", "jemalloc", *std_cargo_args
-      end
-    else
-      cd "bin/reth" do
+      else
         system "cargo", "install", "--bin", "reth", "--profile", "maxperf", *std_cargo_args
       end
     end

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -17,8 +17,14 @@ class Reth < Formula
   depends_on "rust" => :build
 
   def install
-    cd "bin/reth" do
-      system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", "jemalloc", *std_cargo_args
+    if Hardware::CPU.intel?
+        cd "bin/reth" do
+            system "cargo", "install", "--bin", "reth", "--profile", "maxperf", "--features", "jemalloc", *std_cargo_args
+        end
+    else
+        cd "bin/reth" do
+            system "cargo", "install", "--bin", "reth", "--profile", "maxperf", *std_cargo_args
+        end
     end
   end
 

--- a/Formula/reth.rb
+++ b/Formula/reth.rb
@@ -12,7 +12,6 @@ class Reth < Formula
     strategy :github_latest
   end
 
-  depends_on "llvm" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
**Do not merge**

Ref https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

Builds x86 Linux and macOS binaries, as well as macOS ARM binaries in CI. This prevents users from having to build by themselves when using Homebrew unless they explicity want to.

Additionally
- disables jemalloc on non-x86 targets, except for macOS ARM (because the page sizes play nice here)
- enables `asm-keccak` unless we're on ARM linux

Closes #41 