### PR TITLE
chore: disable ubuntu builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -43,4 +43,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: "*.bottle.*"


### PR DESCRIPTION
No one uses brew on Linux, and it adds a lot of complexity to some builds, so there isn't really a point in wasting time on it