### PR TITLE
fix: use unique artifact names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST" --artifact-pattern "bottles-*"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,5 +42,5 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: bottles
+          name: bottles-${{ strategy.job-index }}
           path: "*.bottle.*"


### PR DESCRIPTION
Something changed recently with artifact names, and it's now complaining that we're uploading the same artifact multiple times. This PR adds a unique identifier to each artifact uploaded in the release matrix, and adjusts the final `pr-pull` workflow to download any artifact matching the pattern `bottles-*`